### PR TITLE
WIP: Proof of concept using Loki to store and retrieve logs

### DIFF
--- a/_run/common-commands.mk
+++ b/_run/common-commands.mk
@@ -15,8 +15,9 @@ PRICE          ?= 10uakt
 CERT_HOSTNAME  ?= localhost
 LEASE_SERVICES ?= web
 
-JWT_AUTH_HOSTNAME ?= localhost
-JWT_AUTH_HOST     ?= $(JWT_AUTH_HOSTNAME):8444
+JWT_AUTH_HOSTNAME    ?= localhost
+JWT_AUTH_HOST        ?= $(JWT_AUTH_HOSTNAME):8444
+RESOURCE_SERVER_HOST ?= localhost:8445
 
 .PHONY: multisig-send
 multisig-send:
@@ -69,6 +70,13 @@ auth-server:
 	$(AKASH) provider auth-server \
 		--from "$(PROVIDER_KEY_NAME)" \
 		--jwt-auth-listen-address "$(JWT_AUTH_HOST)" \
+
+.PHONY: run-resource-server
+run-resource-server:
+	$(AKASH) provider run-resource-server \
+		--from "$(PROVIDER_KEY_NAME)" \
+		--resource-server-listen-address "$(RESOURCE_SERVER_HOST)" \
+		--loki-gateway-listen-address localhost:3100 \
 
 .PHONY: send-manifest
 send-manifest:

--- a/_run/common-kind.mk
+++ b/_run/common-kind.mk
@@ -76,6 +76,7 @@ kind-cluster-create: $(KIND)
 		--config "$(KIND_CONFIG)" \
 		--name "$(KIND_NAME)" \
 		--image "$(KIND_IMG)"
+	chmod 600 $$HOME/.kube/config
 	kubectl label nodes $(KIND_NAME)-control-plane akash.network/role=ingress
 	kubectl apply -f "$(INGRESS_CONFIG_PATH)"
 	kubectl apply -f "$(INGRESS_CLASS_CONFIG_PATH)"
@@ -83,20 +84,38 @@ kind-cluster-create: $(KIND)
 	kubectl apply -f "$(METALLB_IP_CONFIG_PATH)"
 	kubectl apply -f "$(METALLB_SERVICE_PATH)"
 	"$(AKASH_ROOT)/script/setup-kind.sh"
+	helm repo add grafana https://grafana.github.io/helm-charts
+	helm repo update
+	helm upgrade --install loki grafana/loki \
+		--version 2.9.1 \
+		--create-namespace \
+		--namespace loki-stack \
+		--set config.table_manager.retention_period=48h,config.table_manager.retention_deletes_enabled=true,persistence.enabled=true,persistence.size=10Gi,persistence.storageClassName=standard,config.auth_enabled=true
+	helm upgrade --install promtail grafana/promtail \
+		--version 3.11.0 \
+		--namespace loki-stack \
+		-f ../promtail-values.yaml
 
-# Create a kubernetes cluster with loki & grafana integrated for logging.
+
+# Create a kubernetes cluster with multi-tenant loki, promtail and grafana integrated for logging.
 # See: https://www.scaleway.com/en/docs/tutorials/manage-k8s-logging-loki/ for more info.
 .PHONY: kind-cluster-loki-create
 kind-cluster-loki-create: kind-cluster-create
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo update
-	helm install loki-stack grafana/loki-stack \
+	helm upgrade --install loki grafana/loki \
+		--version 2.9.1 \
 		--create-namespace \
 		--namespace loki-stack \
-		--set promtail.enabled=true,loki.persistence.enabled=true,loki.persistence.size=10Gi
-	helm install loki-grafana grafana/grafana \
-		--set persistence.enabled=true,persistence.type=pvc,persistence.size=10Gi \
-		--namespace=loki-stack
+		--set persistence.enabled=true,persistence.size=10Gi,config.auth_enabled=true
+	helm upgrade --install promtail grafana/promtail \
+		--version 3.11.0 \
+		--namespace loki-stack \
+		-f ../promtail-values.yaml
+	helm upgrade --install grafana grafana/grafana \
+		--version 6.21.2 \
+		--namespace loki-stack \
+		--set persistence.enabled=true,persistence.type=pvc,persistence.size=10Gi
 
 .PHONY: kind-cluster-calico-create
 kind-cluster-calico-create: $(KIND)

--- a/_run/kube/Makefile
+++ b/_run/kube/Makefile
@@ -19,7 +19,8 @@ provider-run:
 		--cluster-node-port-quantity 100 \
 		--cluster-public-hostname "$(GATEWAY_HOSTNAME)" \
 		--bid-price-strategy "randomRange" \
-		--deployment-runtime-class "none"
+		--deployment-runtime-class "none" \
+		--hostname-operator-endpoint "localhost:8085"
 
 .PHONY: provider-lease-status
 provider-lease-status:

--- a/_run/kube/deployment.yaml
+++ b/_run/kube/deployment.yaml
@@ -15,7 +15,6 @@ services:
           - hello.localhost
         to:
           - global: true
-            ip: "foobario"
   bew:
     image: quay.io/ovrclk/demo-app
     expose:
@@ -54,6 +53,3 @@ deployment:
     westcoast:
       profile: web
       count: 1
-endpoints:
-  foobario:
-    kind: ip

--- a/_run/promtail-values.yaml
+++ b/_run/promtail-values.yaml
@@ -1,0 +1,7 @@
+config:
+  lokiAddress: http://loki.loki-stack:3100/loki/api/v1/push
+  snippets:
+    pipelineStages:
+      - cri: {}
+      - tenant:
+          source: namespace

--- a/provider/cluster/kube/loki/loki.go
+++ b/provider/cluster/kube/loki/loki.go
@@ -1,0 +1,15 @@
+package loki
+
+/*
+import (
+	loki "github.com/grafana/loki/pkg/logcli/client"
+)
+
+type client struct {
+	lc loki.Client
+}
+
+func (c *client) GetLogsByService(serviceName string) {
+
+}
+*/

--- a/provider/cluster/kube/loki/loki.go
+++ b/provider/cluster/kube/loki/loki.go
@@ -192,7 +192,7 @@ type entry struct {
 //Stream represents a log stream.  It includes a set of log entries and their labels.
 type stream struct {
 	Labels  map[string]string `json:"stream"`
-	Entries []entry  `json:"values"`
+	Entries [][]string  `json:"values"`
 }
 
 // tailResponse represents the http json response to a tail query from loki
@@ -273,7 +273,9 @@ func (c *client) TailLogsByService(ctx context.Context, leaseID mtypes.LeaseID, 
 
 		for _, stream := range logs.Streams {
 			for _, entry := range stream.Entries {
-				err = eachLogLine(entry.Timestamp, entry.Line)
+				at := time.Time{} // TODO
+				line := entry[1]
+				err = eachLogLine(at, line)
 				if err != nil {
 					return err
 				}

--- a/provider/cluster/kube/loki/loki.go
+++ b/provider/cluster/kube/loki/loki.go
@@ -142,11 +142,16 @@ func (c *client) GetLogByService(ctx context.Context, leaseID mtypes.LeaseID, se
 		return LogResult{},err
 	}
 
+	// TODO - if runIndex >= 0 then launch a query to get a single log line back from the backend
+	// then use that log line to determine the correct label to query on. Will need to parse it out and then
+	// modify it to be the expected value
+
 	httpQueryString := url.Values{}
 	httpQueryString.Set("start", fmt.Sprintf("%d", startTime.UnixNano()))
 	httpQueryString.Set("end", fmt.Sprintf("%d", endTime.UnixNano()))
 	httpQueryString.Set("limit", "1000") // TODO - configurable or something? Maybe user requestable?
 	// TODO - guard against injection here even though it is unlikely
+	// TODO - specify filename label here if runIndex >= 0
 	lokiQuery := fmt.Sprintf("{pod=%q}", podName) // Note this is not JSON
 	// TODO - query by run index as well ? do I even need this
 	httpQueryString.Set("query", lokiQuery)

--- a/provider/cluster/kube/loki/loki.go
+++ b/provider/cluster/kube/loki/loki.go
@@ -1,15 +1,232 @@
 package loki
 
-/*
+/**
+Some code in this file is from the Loki project v1.6.1. It uses the Apache License version 2.0 which is the
+same as this project.
+ */
+
 import (
-	loki "github.com/grafana/loki/pkg/logcli/client"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	clusterutil "github.com/ovrclk/akash/provider/cluster/util"
+	mtypes "github.com/ovrclk/akash/x/market/types/v1beta2"
+	"github.com/tendermint/tendermint/libs/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"net"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
 )
 
+const (
+	lokiNamespace = "loki-stack"
+	lokiServiceName = "loki-headless"
+	lokiPortName = "http-metrics"
+
+	queryPath       = "/loki/api/v1/query"
+	queryRangePath  = "/loki/api/v1/query_range"
+	labelsPath      = "/loki/api/v1/labels"
+	labelValuesPath = "/loki/api/v1/label/%s/values"
+	seriesPath      = "/loki/api/v1/series"
+	tailPath        = "/loki/api/v1/tail"
+	filenameLabel = "filename"
+	podLabel = "pod"
+	lokiOrgIdHeader = "X-Scope-OrgID"
+)
+
+var (
+	ErrLoki = errors.New("error querying loki")
+)
+
+type Client interface {
+	FindLogsByLease(ctx context.Context, leaseID mtypes.LeaseID) ([]LogStatus, error)
+	Stop()
+}
+
+func NewClient(logger log.Logger, kubeConfig *rest.Config, port *net.SRV) (Client, error) {
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	sda, err := clusterutil.NewServiceDiscoveryAgent(logger, kubeConfig, lokiPortName, lokiServiceName, lokiNamespace, port)
+	if err != nil {
+		return nil, err
+	}
+	return &client{
+		sda:sda,
+		lock: &sync.Mutex{},
+		kc: kubeClient,
+	}, nil
+}
+
 type client struct {
-	lc loki.Client
+	sda clusterutil.ServiceDiscoveryAgent
+	kc kubernetes.Interface
+	client clusterutil.ServiceClient
+	lock sync.Locker
 }
 
-func (c *client) GetLogsByService(serviceName string) {
+func (c *client) Stop() {
+	c.sda.Stop()
+}
+
+func (c *client) GetLogByService(ctx context.Context, leaseID mtypes.LeaseID, serviceName string, replicaIndex uint, runIndex uint, startTime, endTime time.Time) {
 
 }
-*/
+
+func (c *client) getLokiClient(ctx context.Context) (clusterutil.ServiceClient, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.client == nil {
+		var err error
+		c.client, err = c.sda.GetClient(ctx, false, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.client, nil
+}
+
+type lokiLabelValuesResponse struct {
+	Status string `json:"status"`
+	Data []string `json:"data"`
+}
+
+type LogStatus struct {
+	ServiceName string
+	ReplicaIndex int
+	Present bool
+}
+func (c *client) FindLogsByLease(ctx context.Context, leaseID mtypes.LeaseID) ([]LogStatus, error) {
+	lidNS := clusterutil.LeaseIDToNamespace(leaseID)
+	lc, err := c.getLokiClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// get a list of possible logs for this service
+	possiblePods, err := c.detectRunsForLease(ctx, leaseID)
+
+	// Query Loki for labels of the log filename. The label has a value like
+	//   /var/log/pods/7ev5rjb3nfl9niulmnpaft53g27rck4fhm6v3n4nb5jvu_web-bb84fdfcf-brx2z_f192c48e-ccb3-441e-9778-58de019259d6/web/0.log
+	// Where the last part of the filename is the associated restart number. The label value only appears if
+	// the container actually logged something before it terminates. So, we can check the labels and parse out
+	// that number to determine what containers logged anything before they died
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := lc.CreateRequest(ctx,
+		http.MethodGet,
+		fmt.Sprintf(labelValuesPath, podLabel),
+		nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO - on the query set end=1646072848813679310&start=1646065648813679310 or similar query args
+	// Based on the retention set on the provider
+	req.Header.Add(lokiOrgIdHeader, lidNS)
+	resp, err := lc.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%w: fetching loki label values failed, got status code %d", ErrLoki, resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	result := lokiLabelValuesResponse{}
+	err = decoder.Decode(&result)
+	if err != nil  {
+		return nil, fmt.Errorf("decoding loki label values failed: %w", err)
+	}
+
+	// Assign pods a replica index by their name, so it is consistent. This is done elsewhere as well
+	podNames := make([]string, 0, len(possiblePods))
+	for podName := range possiblePods {
+		podNames = append(podNames, podName)
+	}
+	sort.Strings(podNames)
+	podNameToReplicaIndex := make(map[string]int)
+	for i, podName := range podNames {
+		podNameToReplicaIndex[podName] = i
+	}
+
+	returnValue := make([]LogStatus, len(podNameToReplicaIndex))
+	// By default nothing is found
+	for possiblePodName, entry := range possiblePods {
+		replicaIndex := podNameToReplicaIndex[possiblePodName]
+		returnValue[replicaIndex] = LogStatus{
+			ServiceName:  entry.serviceName,
+			ReplicaIndex: replicaIndex,
+		}
+	}
+
+	// Mark each pod that is found by name
+	for _, podName := range result.Data {
+		i, exists := podNameToReplicaIndex[podName]
+		if !exists {
+			continue
+		}
+		returnValue[i].Present = true
+	}
+
+	// TODO - query by pod name and then figure out how many restarts actually logged something?
+
+	return returnValue, nil
+}
+
+type runEntry struct {
+	restarts uint
+	serviceName string
+}
+func (c *client) detectRunsForLease(ctx context.Context, leaseID mtypes.LeaseID) (map[string]runEntry, error) {
+	// Containers can run more than once (i.e. a pod restarts containers when configured to do so)
+	// so this code picks up on that by looking into the labels
+	lidNS := clusterutil.LeaseIDToNamespace(leaseID)
+	// TODO - paginate
+	podsResult, err := c.kc.CoreV1().Pods(lidNS).List(ctx, metav1.ListOptions{
+		// TODO - use a constant here
+		LabelSelector:        "akash.network=true",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(podsResult.Items) == 0 {
+		return nil, fmt.Errorf("%w: lease %q has no pods in kubernetes", ErrLoki, leaseID.String())
+	}
+
+	// Build up a mapping of pod names to the expected number of log files
+	result := make(map[string]runEntry)
+	for _, pod := range podsResult.Items {
+		// We only define pods with a single container at this time
+		if len(pod.Status.ContainerStatuses) != 1 {
+			return nil, fmt.Errorf("%w: pod %q has %d containers, expected 1", ErrLoki, pod.Name, len(pod.Status.ContainerStatuses))
+		}
+		status := pod.Status.ContainerStatuses[0]
+
+		// TODO - use a constant
+		serviceName, ok := pod.ObjectMeta.Labels["akash.network/manifest-service"]
+		if !ok {
+			return nil, fmt.Errorf("%w: pod %q has no akash service name label", ErrLoki, pod.Name)
+		}
+
+		result[pod.Name] = runEntry{
+			restarts:    uint(status.RestartCount),
+			serviceName: serviceName,
+		}
+	}
+
+	return result, nil
+}

--- a/provider/cluster/util/service_client.go
+++ b/provider/cluster/util/service_client.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/gorilla/websocket"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 )
 
 func (hwsc *httpWrapperServiceClient) CreateRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
@@ -22,6 +25,7 @@ func (hwsc *httpWrapperServiceClient) CreateRequest(ctx context.Context, method,
 func (hwsc *httpWrapperServiceClient) DoRequest(req *http.Request) (*http.Response, error) {
 	return hwsc.httpClient.Do(req)
 }
+
 
 func newHTTPWrapperServiceClient(isHTTPS, secure bool, baseURL string) *httpWrapperServiceClient {
 	netDialer := &net.Dialer{}
@@ -63,4 +67,36 @@ func newHTTPWrapperServiceClientWithTransport(transport http.RoundTripper, baseU
 			Transport: transport,
 		},
 	}
+}
+
+
+func newWebsocketWrapperServiceClientFromDialer(dialer websocket.Dialer, baseURL string) *websocketWrapperServiceClient {
+	return &websocketWrapperServiceClient{
+		url: baseURL,
+		dialer: &dialer,
+	}
+}
+
+func (wwsc *websocketWrapperServiceClient) DialWebsocket(ctx context.Context, path string, requestHeaders http.Header) (*websocket.Conn, error) {
+	dialUrl := fmt.Sprintf("%s/%s", wwsc.url, path)
+
+	if strings.HasPrefix(dialUrl, "https") {
+		dialUrl = strings.Replace(dialUrl, "https", "wss", 1)
+	} else if strings.HasPrefix(dialUrl, "http") {
+		dialUrl = strings.Replace(dialUrl, "http", "ws", 1)
+	}
+
+	conn, resp, err  := wwsc.dialer.DialContext(ctx, dialUrl, requestHeaders)
+	if err != nil {
+		if resp == nil {
+			return nil, err
+		}
+
+		buf, _ := ioutil.ReadAll(resp.Body) // nolint
+		return nil, fmt.Errorf("%w: error response from server when dialing websocket; status %v; response: %s", err, resp.StatusCode,
+			string(buf))
+	}
+
+	return conn, err
+
 }

--- a/provider/cluster/util/service_discovery_agent.go
+++ b/provider/cluster/util/service_discovery_agent.go
@@ -29,6 +29,7 @@ func NewServiceDiscoveryAgent(logger log.Logger, kubeConfig *rest.Config, portNa
 		return staticServiceDiscoveryAgent(*endpoint), nil
 	}
 
+	// TODO - only assign this if that discovery mode is selected
 	kc, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err

--- a/provider/cluster/util/service_discovery_agent_static.go
+++ b/provider/cluster/util/service_discovery_agent_static.go
@@ -19,3 +19,8 @@ func (ssda staticServiceDiscoveryAgent) GetClient(ctx context.Context, isHTTPS, 
 	url := fmt.Sprintf("%s://%v:%v", proto, ssda.Target, ssda.Port)
 	return newHTTPWrapperServiceClient(isHTTPS, secure, url), nil
 }
+
+func (ssda staticServiceDiscoveryAgent) GetWebsocketClient(ctx context.Context, isHTTP, secure bool) (WebsocketServiceClient, error) {
+	// TODO
+	panic("not implemented")
+}

--- a/provider/cluster/util/service_discovery_agent_types.go
+++ b/provider/cluster/util/service_discovery_agent_types.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"github.com/boz/go-lifecycle"
+	"github.com/gorilla/websocket"
 	"github.com/tendermint/tendermint/libs/log"
 	"io"
 	"k8s.io/client-go/kubernetes"
@@ -13,12 +14,17 @@ import (
 type ServiceDiscoveryAgent interface {
 	Stop()
 	GetClient(ctx context.Context, isHTTPS, secure bool) (ServiceClient, error)
+	GetWebsocketClient(ctx context.Context, isHTTPS, secure bool) (WebsocketServiceClient, error)
 	DiscoverNow()
 }
 
 type ServiceClient interface {
 	CreateRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error)
 	DoRequest(req *http.Request) (*http.Response, error)
+}
+
+type WebsocketServiceClient interface {
+	DialWebsocket(ctx context.Context, path string, requestHeader http.Header) (*websocket.Conn, error)
 }
 
 type serviceDiscoveryAgent struct {
@@ -43,9 +49,18 @@ type serviceDiscoveryRequest struct {
 	resultCh chan<- clientFactory
 }
 
-type clientFactory func(isHttps, secure bool) ServiceClient
+type clientFactory interface {
+	MakeServiceClient(isHTTPS, secure bool) ServiceClient
+	MakeWebsocketServiceClient(isHTTPS, secure bool)  WebsocketServiceClient
+}
 
 type httpWrapperServiceClient struct {
 	httpClient *http.Client
 	url        string
 }
+
+type websocketWrapperServiceClient struct {
+	url        string
+	dialer *websocket.Dialer
+}
+

--- a/provider/cmd/leaseLogs.go
+++ b/provider/cmd/leaseLogs.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
+	"time"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -18,13 +23,22 @@ import (
 	cutils "github.com/ovrclk/akash/x/cert/utils"
 )
 
+const(
+	FlagStartTime = "start-time"
+	FlagEndTime = "end-time"
+	FlagForward = "forward"
+	FlagLimit = "limit"
+	FlagRunIndex = "run-index"
+)
+
 func leaseLogsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "lease-logs",
 		Short:        "get lease logs",
 		SilenceUsage: true,
+		Args:         cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doLeaseLogs(cmd)
+			return doLeaseLogsV2(cmd, args)
 		},
 	}
 
@@ -33,6 +47,11 @@ func leaseLogsCmd() *cobra.Command {
 	cmd.Flags().BoolP(flagFollow, "f", false, "Specify if the logs should be streamed. Defaults to false")
 	cmd.Flags().Int64P(flagTail, "t", -1, "The number of lines from the end of the logs to show. Defaults to -1")
 	cmd.Flags().StringP(flagOutput, "o", outputText, "Output format text|json. Defaults to text")
+	cmd.Flags().Bool(FlagForward, true, "")
+	cmd.Flags().String(FlagEndTime, "", "")
+	cmd.Flags().String(FlagStartTime, "", "")
+	cmd.Flags().Uint(FlagLimit, 100, "")
+	cmd.Flags().Int(FlagRunIndex, -1, "")
 
 	return cmd
 }
@@ -52,9 +71,82 @@ func leaseLogStatusCmd() *cobra.Command {
 	return cmd
 }
 
+func withLeasesForDeployment(ctx context.Context, cctx sdkclient.Context, deploymentID dtypes.DeploymentID, provider string,gseq, oseq uint32, fn func(leaseID mtypes.LeaseID) error) error {
+	filter := mtypes.LeaseFilters{
+		Owner: deploymentID.Owner,
+		DSeq:  deploymentID.DSeq,
+		State: mtypes.Lease_State_name[int32(mtypes.LeaseActive)],
+	}
+
+	if len(provider) != 0 {
+		filter.Provider = provider
+	}
+
+	if gseq > 0 {
+		filter.GSeq = gseq
+	}
+
+	if oseq > 0 {
+		filter.OSeq = oseq
+	}
+
+	cclient := akashclient.NewQueryClientFromCtx(cctx)
+	resp, err := cclient.Leases(ctx, &mtypes.QueryLeasesRequest{
+		Filters: filter,
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Leases) == 0 {
+		msg := &bytes.Buffer{}
+		_, _ = fmt.Fprintf(msg, "dseq=%v", filter.DSeq)
+		if len(provider) > 0 {
+			_, _ = fmt.Fprintf(msg, " provider=%v", filter.Provider)
+		}
+		if filter.GSeq > 0 {
+			_, _ = fmt.Fprintf(msg, " gseq=%v", filter.GSeq)
+		}
+		if filter.OSeq > 0 {
+			_, _ = fmt.Fprintf(msg, " oseq=%v", filter.OSeq)
+		}
+		return fmt.Errorf("%w: %s",errNoActiveLease, msg.String())
+	}
+
+	for _, lease := range resp.Leases {
+		err = fn(lease.Lease.LeaseID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func doLeaseLogsStatus(cmd *cobra.Command) error {
-	/**
 	cctx, err := sdkclient.GetClientTxContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	dseq, err := dseqFromFlags(cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	deploymentID := dtypes.DeploymentID{
+		Owner: cctx.GetFromAddress().String(),
+		DSeq:  dseq,
+	}
+
+	provider, err := cmd.Flags().GetString(FlagProvider)
+	if err != nil {
+		return err
+	}
+	gseq, err := cmd.Flags().GetUint32(FlagGSeq)
+	if err != nil {
+		return err
+	}
+	oseq, err := cmd.Flags().GetUint32(FlagOSeq)
 	if err != nil {
 		return err
 	}
@@ -64,101 +156,158 @@ func doLeaseLogsStatus(cmd *cobra.Command) error {
 		return markRPCServerError(err)
 	}
 
+	return withLeasesForDeployment(cmd.Context(),
+		cctx,
+		deploymentID,
+		provider,
+		gseq,
+		oseq,
+		func(leaseID mtypes.LeaseID) error {
+			// TODO - use client directory object here?
+			prov, _ := sdk.AccAddressFromBech32(leaseID.GetProvider())
+			gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), prov, []tls.Certificate{cert})
+			if err != nil {
+				return err
+			}
+			status, err := gclient.LeaseLogsStatus(cmd.Context(), leaseID)
+			if err != nil {
+				 return err
+			}
+
+			_ = status // TODO - print status
+			buf := &bytes.Buffer{}
+			encoder := json.NewEncoder(buf)
+			err = encoder.Encode(status)
+			if err != nil {
+				return err
+			}
+			return cctx.PrintBytes(buf.Bytes())
+		})
+}
+
+
+
+func doLeaseLogsV2(cmd *cobra.Command, args []string) error {
+	serviceName := args[0]
+	replicaIndexStr := args[1]
+
+	replicaIndex, err := strconv.ParseUint(replicaIndexStr, 10, 31)
+	if err != nil {
+		// TODO - better error here
+		return err
+	}
+
+	cctx, err := sdkclient.GetClientTxContext(cmd)
+	if err != nil {
+		return err
+	}
+
 	dseq, err := dseqFromFlags(cmd.Flags())
 	if err != nil {
 		return err
 	}
 
-	leases, err := leasesForDeployment(cmd.Context(), cctx, cmd.Flags(), dtypes.DeploymentID{
+	deploymentID := dtypes.DeploymentID{
 		Owner: cctx.GetFromAddress().String(),
 		DSeq:  dseq,
-	})
-	if err != nil {
-		return markRPCServerError(err)
 	}
 
-	svcs, err := cmd.Flags().GetString(FlagService)
+	provider, err := cmd.Flags().GetString(FlagProvider)
+	if err != nil {
+		return err
+	}
+	gseq, err := cmd.Flags().GetUint32(FlagGSeq)
+	if err != nil {
+		return err
+	}
+	oseq, err := cmd.Flags().GetUint32(FlagOSeq)
 	if err != nil {
 		return err
 	}
 
-	type result struct {
-		lid    mtypes.LeaseID
-		error  error
-		stream *gwrest.ServiceLogs
+	cert, err := cutils.LoadAndQueryCertificateForAccount(cmd.Context(), cctx, cctx.Keyring)
+	if err != nil {
+		return markRPCServerError(err)
 	}
 
-	streams := make([]result, 0, len(leases))
+	limit, err := cmd.Flags().GetUint(FlagLimit)
+	if err != nil {
+		return err
+	}
+	startTimeStr, err := cmd.Flags().GetString(FlagStartTime)
+	if err != nil {
+		return err
+	}
+	endTimeStr,err := cmd.Flags().GetString(FlagEndTime)
+	if err != nil {
+		return err
+	}
+	forward, err := cmd.Flags().GetBool(FlagForward)
+	if err != nil {
+		return err
+	}
+	runIndex, err := cmd.Flags().GetInt(FlagRunIndex)
 
-	ctx := cmd.Context()
-
-	for _, lid := range leases {
-		stream := result{lid: lid}
-		prov, _ := sdk.AccAddressFromBech32(lid.Provider)
-		gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), prov, []tls.Certificate{cert})
-		if err == nil {
-			stream.stream, stream.error = gclient.LeaseLogs(ctx, lid, svcs, follow, tailLines)
-		} else {
-			stream.error = err
+	startTime := time.Time{}
+	if len(startTimeStr) != 0 {
+		startTime, err = time.Parse(time.RFC3339, startTimeStr)
+		if err != nil {
+			return err
 		}
-
-		streams = append(streams, stream)
 	}
-
-	var wgStreams sync.WaitGroup
-
-	type logEntry struct {
-		gwrest.ServiceLogMessage `json:",inline"`
-		Lid                      mtypes.LeaseID `json:"lease_id"`
-	}
-
-	outch := make(chan logEntry)
-
-	printFn := func(evt logEntry) {
-		fmt.Printf("[%s][%s] %s\n", evt.Lid, evt.Name, evt.Message)
-	}
-
-	if outputFormat == "json" {
-		printFn = func(evt logEntry) {
-			_ = cmdcommon.PrintJSON(cctx, evt)
+	endTime := time.Time{}
+	if len(endTimeStr) != 0 {
+		endTime, err = time.Parse(time.RFC3339, endTimeStr)
+		if err != nil {
+			return err
 		}
 	}
 
-	go func() {
-		for evt := range outch {
-			printFn(evt)
-		}
-	}()
-
-	for _, stream := range streams {
-		if stream.error != nil {
-			continue
-		}
-
-		wgStreams.Add(1)
-		go func(stream result) {
-			defer wgStreams.Done()
-
-			for res := range stream.stream.Stream {
-				outch <- logEntry{
-					ServiceLogMessage: res,
-					Lid:               stream.lid,
-				}
+	return withLeasesForDeployment(cmd.Context(),
+		cctx,
+		deploymentID,
+		provider,
+		gseq,
+		oseq,
+		func(leaseID mtypes.LeaseID) error {
+			// TODO - use client directory object here?
+			prov, _ := sdk.AccAddressFromBech32(leaseID.GetProvider())
+			gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), prov, []tls.Certificate{cert})
+			if err != nil {
+				return err
 			}
-		}(stream)
-	}
 
-	wgStreams.Wait()
-	close(outch)
+			result, err := gclient.LeaseLogsV2(cmd.Context(),
+				leaseID,
+				serviceName,
+				uint(replicaIndex),
+				runIndex,
+				startTime,
+				endTime,
+				forward,
+				limit)
 
-	return nil
+			if err != nil {
+				clientError, ok := err.(gwrest.ClientResponseError)
+				if ok{
+					_ = cctx.PrintString(clientError.ClientError())
+				}
+				return err
+			}
 
-	 */
-	return nil
+			// TODO - check output flag for format
+			buf := &bytes.Buffer{}
+			encoder := json.NewEncoder(buf)
+			err = encoder.Encode(result)
+			if err != nil {
+				return err
+			}
+
+			return cctx.PrintBytes(buf.Bytes())
+		})
 }
 
 func doLeaseLogs(cmd *cobra.Command) error {
-
 	// TODO - clean up most of this into some sort of simple "withEachLease" function that calls a
 	// function for each lease found
 	cctx, err := sdkclient.GetClientTxContext(cmd)

--- a/provider/cmd/root.go
+++ b/provider/cmd/root.go
@@ -36,6 +36,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(AuthenticateCmd())
 	cmd.AddCommand(clusterNSCmd())
 	cmd.AddCommand(migrate())
+	cmd.AddCommand(RunResourceServerCmd())
 
 	return cmd
 }

--- a/provider/cmd/root.go
+++ b/provider/cmd/root.go
@@ -37,6 +37,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(clusterNSCmd())
 	cmd.AddCommand(migrate())
 	cmd.AddCommand(RunResourceServerCmd())
+	cmd.AddCommand(leaseLogStatusCmd())
 
 	return cmd
 }

--- a/provider/cmd/run_resource_server.go
+++ b/provider/cmd/run_resource_server.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net/http"
+
+	"golang.org/x/sync/errgroup"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/ovrclk/akash/cmd/common"
+	gwrest "github.com/ovrclk/akash/provider/gateway/rest"
+	cutils "github.com/ovrclk/akash/x/cert/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	FlagResourceServerListenAddress = "resource-server-listen-address"
+	FlagLokiGatewayListenAddress    = "loki-gateway-listen-address"
+)
+
+var (
+	ErrEcdsaPubkeyExpected = errors.New("expected a ecdsa public key")
+)
+
+func RunResourceServerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "run-resource-server",
+		Short: "Run the resource server which authenticates tenants based on JWT before" +
+			" providing access to resources",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return common.RunForeverWithContext(cmd.Context(), func(ctx context.Context) error {
+				return doRunResourceServer(ctx, cmd, args)
+			})
+		},
+	}
+	flags.AddTxFlagsToCmd(cmd)
+
+	cmd.Flags().String(FlagResourceServerListenAddress, "0.0.0.0:8445",
+		"`host:port` for the resource server to listen on")
+	if err := viper.BindPFlag(FlagResourceServerListenAddress, cmd.Flags().Lookup(FlagResourceServerListenAddress)); err != nil {
+		return nil
+	}
+
+	cmd.Flags().String(FlagLokiGatewayListenAddress, "localhost:3100",
+		"`host:port` where the loki instance is exposed on provider's network")
+	if err := viper.BindPFlag(FlagLokiGatewayListenAddress, cmd.Flags().Lookup(FlagLokiGatewayListenAddress)); err != nil {
+		return nil
+	}
+
+	cmd.Flags().String(FlagAuthPem, "", "")
+
+	return cmd
+}
+
+func doRunResourceServer(ctx context.Context, cmd *cobra.Command, _ []string) error {
+	gwAddr := viper.GetString(FlagResourceServerListenAddress)
+	lokiGwAddr := viper.GetString(FlagLokiGatewayListenAddress)
+
+	cctx, err := sdkclient.GetClientTxContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	txFactory := tx.NewFactoryCLI(cctx, cmd.Flags()).WithTxConfig(cctx.TxConfig).WithAccountRetriever(cctx.AccountRetriever)
+
+	var certFromFlag io.Reader
+	if val := cmd.Flag(FlagAuthPem).Value.String(); val != "" {
+		certFromFlag = bytes.NewBufferString(val)
+	}
+
+	cpem, err := cutils.LoadPEMForAccount(cctx, txFactory.Keybase(), cutils.PEMFromReader(certFromFlag))
+	if err != nil {
+		return err
+	}
+
+	blk, _ := pem.Decode(cpem.Cert)
+	x509cert, err := x509.ParseCertificate(blk.Bytes)
+	if err != nil {
+		return err
+	}
+
+	pubkey, ok := x509cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return ErrEcdsaPubkeyExpected
+	}
+
+	group, ctx := errgroup.WithContext(ctx)
+	log := openLogger()
+
+	resourceServer, err := gwrest.NewResourceServer(ctx, log, gwAddr, cctx.FromAddress, pubkey, lokiGwAddr)
+	if err != nil {
+		return err
+	}
+
+	group.Go(func() error {
+		return resourceServer.ListenAndServe()
+	})
+
+	group.Go(func() error {
+		<-ctx.Done()
+		return resourceServer.Close()
+	})
+
+	err = group.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	return nil
+}

--- a/provider/gateway/rest/client.go
+++ b/provider/gateway/rest/client.go
@@ -941,12 +941,18 @@ func (c *client) LeaseLogsV2Follow(ctx context.Context, leaseID mtypes.LeaseID,
 
 	for {
 		msg := []interface{}{nil, nil}
-		err := ws.ReadJSON(&msg)
+		_, r, err := ws.NextReader()
+		if err != nil {
+			return err
+		}
+		dec := json.NewDecoder(r)
+		dec.UseNumber()
+		err = dec.Decode(&msg)
 		if err != nil {
 			return err
 		}
 
-		atNum, ok := msg[0].(*json.Number)
+		atNum, ok := msg[0].(json.Number)
 		if !ok {
 			return fmt.Errorf("%w: expected number at index 0 of log line, got %T", errBadLogLine, msg[0])
 		}

--- a/provider/gateway/rest/path.go
+++ b/provider/gateway/rest/path.go
@@ -52,3 +52,11 @@ func serviceStatusPath(id mtypes.LeaseID, service string) string {
 func serviceLogsPath(id mtypes.LeaseID) string {
 	return fmt.Sprintf("%s/logs", leasePath(id))
 }
+
+func leaseLogsStatusPath(leaseID mtypes.LeaseID) string {
+	return fmt.Sprintf("%s/logs/status", leasePath(leaseID))
+}
+
+func leaseLogsQuery(leaseID mtypes.LeaseID, serviceName string, replicaIndex uint) string {
+	return fmt.Sprintf("%s/logs/query/%s/%d", leasePath(leaseID), serviceName, replicaIndex)
+}

--- a/provider/gateway/rest/router.go
+++ b/provider/gateway/rest/router.go
@@ -211,6 +211,7 @@ func logQueryFollowHandler(logger log.Logger,
 		return
 	}
 
+	// TODO - figoure out how to flush this at a regular cadence to avoid buffering ?
 	ws.EnableWriteCompression(true)
 	sendLogLine := func(at time.Time, line string) error {
 		err := ws.SetWriteDeadline(time.Now().Add(time.Second * 10)) // TODO - configurable ???
@@ -239,6 +240,14 @@ func logQueryFollowHandler(logger log.Logger,
 		}
 	}
 
+	err = ws.WriteControl(websocket.CloseMessage,[]byte{}, time.Now().Add(time.Second * 30))
+	if err != nil {
+		logger.Error("could not send websocket close message", "err", err)
+	}
+	err = ws.Close()
+	if err != nil {
+		logger.Error("could not close websocket", "err", err)
+	}
 }
 
 func logQueryHandler(logger log.Logger, lokiClient loki.Client) http.HandlerFunc{

--- a/provider/gateway/rest/router.go
+++ b/provider/gateway/rest/router.go
@@ -197,14 +197,21 @@ func logQueryHandler(logger log.Logger, lokiClient loki.Client) http.HandlerFunc
 
 		replicaIndex, err :=  strconv.ParseUint(replicaIndexStr, 10, 31)
 		if err != nil {
-			logger.Error("could not parse path compeonent for replica index", "err", err, "replicaIndex", replicaIndexStr)
+			logger.Error("could not parse path component for replica index", "err", err, "replicaIndex", replicaIndexStr)
 			rw.WriteHeader(http.StatusNotFound)
 			return
 		}
 
+		// TODO - validate replica index
+
+		// TODO - get the following from the query, with defaults
+		// runIndex
+		// start time
+		// end time
+
 		logs, err := lokiClient.GetLogByService(req.Context(),leaseID, serviceName, uint(replicaIndex),
 			-1,
-			time.Now().Add(time.Hour * 72 * -1), // TODO - configurable
+			time.Now().Add(time.Hour * 72 * -1), // TODO - configurable. Loki apparently has a default time limit of 720hrs here
 			time.Now(), false)
 
 		if err != nil {

--- a/provider/gateway/rest/router.go
+++ b/provider/gateway/rest/router.go
@@ -224,11 +224,12 @@ func logQueryFollowHandler(logger log.Logger,
 	// TODO - figoure out how to flush this at a regular cadence to avoid buffering ?
 	ws.EnableWriteCompression(true)
 	sendLogLine := func(at time.Time, line string) error {
+		msg := []interface{}{at.UnixNano(), line}
 		err := ws.SetWriteDeadline(time.Now().Add(time.Second * 10)) // TODO - configurable ???
 		if err != nil {
 			return err
 		}
-		return ws.WriteMessage(websocket.TextMessage, []byte(line))
+		return ws.WriteJSON(msg)
 	}
 
 	onDropped := func() error {

--- a/provider/gateway/rest/server.go
+++ b/provider/gateway/rest/server.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/tls"
 	"github.com/ovrclk/akash/provider/cluster/operatorclients"
 	"net"
@@ -65,6 +66,22 @@ func NewJwtServer(ctx context.Context,
 	srv.TLSConfig, err = gwutils.NewServerTLSConfig(ctx, []tls.Certificate{cert}, cquery)
 	if err != nil {
 		return nil, err
+	}
+
+	return srv, nil
+}
+
+func NewResourceServer(ctx context.Context,
+	log log.Logger,
+	serverAddr string,
+	providerAddr sdk.Address,
+	pubkey *ecdsa.PublicKey,
+	lokiGwAddr string,
+) (*http.Server, error) {
+	srv := &http.Server{
+		Addr:        serverAddr,
+		Handler:     newResourceServerRouter(log, providerAddr, pubkey, lokiGwAddr),
+		BaseContext: func(_ net.Listener) context.Context { return ctx },
 	}
 
 	return srv, nil

--- a/provider/gateway/rest/server.go
+++ b/provider/gateway/rest/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/tls"
+	"github.com/ovrclk/akash/provider/cluster/kube/loki"
 	"github.com/ovrclk/akash/provider/cluster/operatorclients"
 	"net"
 	"net/http"
@@ -23,6 +24,7 @@ func NewServer(
 	pclient provider.Client,
 	cquery ctypes.QueryClient,
 	ipopclient operatorclients.IPOperatorClient,
+	lokiClient loki.Client,
 	address string,
 	pid sdk.Address,
 	certs []tls.Certificate,
@@ -30,7 +32,7 @@ func NewServer(
 
 	srv := &http.Server{
 		Addr:    address,
-		Handler: newRouter(log, pid, pclient, ipopclient, clusterConfig),
+		Handler: newRouter(log, pid, pclient, ipopclient, lokiClient, clusterConfig),
 		BaseContext: func(_ net.Listener) context.Context {
 			return ctx
 		},


### PR DESCRIPTION
This is my proof of concept for using Loki to store & retrieve logs. This is based off my work I did on the metal-lb branch, cleaning up some of the way we interact with operators

**Changes**

1. Add loki to the development environment, running it within kind
2. Add code to query loki's HTTP interface
3. Rework the lease logs command to query loki

Each namespace in Kubernetes becomes an "organization" in Loki. So logs are automatically kept isolated between deployments. Promtail picks up the logs automatically and forwards them to Loki. Accessing this is pretty simple. I wrote a client to make the HTTP request to Loki. Trying to import their client is not very practical and making the actual requests is not complex. I copied some code from Loki, which uses the same license as our project anyways.

Selecting loki and supporting it as our only solution makes sense for now. It is an open source project under active development designed to work with kubernetes. It would be nice to support other log retention solutions but I don't think that is practical for now.

One neat feature I've added is the ability to identify and limit the logs to a specific run of a container. This happens if the container fails & restarts. I think this is helpful because in the case of a container that deploys but fails quickly an end user can request all the logs from a specific run to try and figure out why it is failing. It's still on an end user to deploy a container that logs helpful information, but this should makes things easier.

One thing I haven't tried to account for is running Loki should be optional. If a provider wants to host lots of computational workloads (like miners, or whatever) they shouldn't be required to run Loki. So we need to figure out what to do in that case. Should we just fall back to querying the kube logs?

**Incomplete / Unresolved**
1. Providers need to be configured to limit retention of logs to whatever they have storage for
2. Providers need to configure Loki to rate limit logs to something reasonable. This is an ongoing effort in Loki, hopefully we can pick this up once the changes are merged into a new release.
3. When a lease is closed, we need to signal Loki to clear out all the logs it has retained for that lease. Otherwise Loki could run out of space retaining logs for closed leases.