### PR TITLE
refactor(app): upgrade handlers

### DIFF
--- a/app/app_configure.go
+++ b/app/app_configure.go
@@ -84,59 +84,62 @@ func akashSubspaces(k paramskeeper.Keeper) paramskeeper.Keeper {
 }
 
 func (app *AkashApp) setAkashKeepers() {
-	app.keeper.escrow = ekeeper.NewKeeper(
+	app.Keepers.Akash.Escrow = ekeeper.NewKeeper(
 		app.appCodec,
 		app.keys[escrow.StoreKey],
-		app.keeper.bank,
+		app.Keepers.Cosmos.Bank,
 	)
 
-	app.keeper.deployment = deployment.NewKeeper(
+	app.Keepers.Akash.Deployment = deployment.NewKeeper(
 		app.appCodec,
 		app.keys[deployment.StoreKey],
 		app.GetSubspace(deployment.ModuleName),
-		app.keeper.escrow,
+		app.Keepers.Akash.Escrow,
 	)
 
-	app.keeper.market = market.NewKeeper(
+	app.Keepers.Akash.Market = market.NewKeeper(
 		app.appCodec,
 		app.keys[market.StoreKey],
 		app.GetSubspace(market.ModuleName),
-		app.keeper.escrow,
+		app.Keepers.Akash.Escrow,
 	)
 
-	hook := mhooks.New(app.keeper.deployment, app.keeper.market)
+	hook := mhooks.New(
+		app.Keepers.Akash.Deployment,
+		app.Keepers.Akash.Market,
+	)
 
-	app.keeper.escrow.AddOnAccountClosedHook(hook.OnEscrowAccountClosed)
-	app.keeper.escrow.AddOnPaymentClosedHook(hook.OnEscrowPaymentClosed)
+	app.Keepers.Akash.Escrow.AddOnAccountClosedHook(hook.OnEscrowAccountClosed)
+	app.Keepers.Akash.Escrow.AddOnPaymentClosedHook(hook.OnEscrowPaymentClosed)
 
-	app.keeper.provider = provider.NewKeeper(
+	app.Keepers.Akash.Provider = provider.NewKeeper(
 		app.appCodec,
 		app.keys[provider.StoreKey],
 	)
 
-	app.keeper.audit = audit.NewKeeper(
+	app.Keepers.Akash.Audit = audit.NewKeeper(
 		app.appCodec,
 		app.keys[audit.StoreKey],
 	)
 
-	app.keeper.cert = cert.NewKeeper(
+	app.Keepers.Akash.Cert = cert.NewKeeper(
 		app.appCodec,
 		app.keys[cert.StoreKey],
 	)
 
-	app.keeper.inflation = inflation.NewKeeper(
+	app.Keepers.Akash.Inflation = inflation.NewKeeper(
 		app.appCodec,
 		app.keys[inflation.StoreKey],
 		app.GetSubspace(inflation.ModuleName),
 	)
 
-	app.keeper.astaking = astakingkeeper.NewKeeper(
+	app.Keepers.Akash.Staking = astakingkeeper.NewKeeper(
 		app.appCodec,
 		app.keys[astaking.StoreKey],
 		app.GetSubspace(astaking.ModuleName),
 	)
 
-	app.keeper.agov = agovkeeper.NewKeeper(
+	app.Keepers.Akash.Gov = agovkeeper.NewKeeper(
 		app.appCodec,
 		app.keys[agov.StoreKey],
 		app.GetSubspace(agov.ModuleName),
@@ -147,58 +150,58 @@ func (app *AkashApp) akashAppModules() []module.AppModule {
 	return []module.AppModule{
 		escrow.NewAppModule(
 			app.appCodec,
-			app.keeper.escrow,
+			app.Keepers.Akash.Escrow,
 		),
 
 		deployment.NewAppModule(
 			app.appCodec,
-			app.keeper.deployment,
-			app.keeper.market,
-			app.keeper.escrow,
-			app.keeper.bank,
-			app.keeper.authz,
+			app.Keepers.Akash.Deployment,
+			app.Keepers.Akash.Market,
+			app.Keepers.Akash.Escrow,
+			app.Keepers.Cosmos.Bank,
+			app.Keepers.Cosmos.Authz,
 		),
 
 		market.NewAppModule(
 			app.appCodec,
-			app.keeper.market,
-			app.keeper.escrow,
-			app.keeper.audit,
-			app.keeper.deployment,
-			app.keeper.provider,
-			app.keeper.bank,
+			app.Keepers.Akash.Market,
+			app.Keepers.Akash.Escrow,
+			app.Keepers.Akash.Audit,
+			app.Keepers.Akash.Deployment,
+			app.Keepers.Akash.Provider,
+			app.Keepers.Cosmos.Bank,
 		),
 
 		provider.NewAppModule(
 			app.appCodec,
-			app.keeper.provider,
-			app.keeper.bank,
-			app.keeper.market,
+			app.Keepers.Akash.Provider,
+			app.Keepers.Cosmos.Bank,
+			app.Keepers.Akash.Market,
 		),
 
 		audit.NewAppModule(
 			app.appCodec,
-			app.keeper.audit,
+			app.Keepers.Akash.Audit,
 		),
 
 		cert.NewAppModule(
 			app.appCodec,
-			app.keeper.cert,
+			app.Keepers.Akash.Cert,
 		),
 
 		inflation.NewAppModule(
 			app.appCodec,
-			app.keeper.inflation,
+			app.Keepers.Akash.Inflation,
 		),
 
 		astaking.NewAppModule(
 			app.appCodec,
-			app.keeper.astaking,
+			app.Keepers.Akash.Staking,
 		),
 
 		agov.NewAppModule(
 			app.appCodec,
-			app.keeper.agov,
+			app.Keepers.Akash.Gov,
 		),
 	}
 }
@@ -301,39 +304,39 @@ func (app *AkashApp) akashInitGenesisOrder() []string {
 func (app *AkashApp) akashSimModules() []module.AppModuleSimulation {
 	return []module.AppModuleSimulation{
 		deployment.NewAppModuleSimulation(
-			app.keeper.deployment,
-			app.keeper.acct,
-			app.keeper.bank,
+			app.Keepers.Akash.Deployment,
+			app.Keepers.Cosmos.Acct,
+			app.Keepers.Cosmos.Bank,
 		),
 
 		market.NewAppModuleSimulation(
-			app.keeper.market,
-			app.keeper.acct,
-			app.keeper.deployment,
-			app.keeper.provider,
-			app.keeper.bank,
+			app.Keepers.Akash.Market,
+			app.Keepers.Cosmos.Acct,
+			app.Keepers.Akash.Deployment,
+			app.Keepers.Akash.Provider,
+			app.Keepers.Cosmos.Bank,
 		),
 
 		provider.NewAppModuleSimulation(
-			app.keeper.provider,
-			app.keeper.acct,
-			app.keeper.bank,
+			app.Keepers.Akash.Provider,
+			app.Keepers.Cosmos.Acct,
+			app.Keepers.Cosmos.Bank,
 		),
 
 		cert.NewAppModuleSimulation(
-			app.keeper.cert,
+			app.Keepers.Akash.Cert,
 		),
 
 		inflation.NewAppModuleSimulation(
-			app.keeper.inflation,
+			app.Keepers.Akash.Inflation,
 		),
 
 		astaking.NewAppModuleSimulation(
-			app.keeper.astaking,
+			app.Keepers.Akash.Staking,
 		),
 
 		agov.NewAppModuleSimulation(
-			app.keeper.agov,
+			app.Keepers.Akash.Gov,
 		),
 	}
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -18,7 +18,7 @@ func TestAppExport(t *testing.T) {
 		db, nil, true, 0, map[int64]bool{}, DefaultHome, OptsWithGenesisTime(0))
 
 	for acc := range MacPerms() {
-		require.Equal(t, !allowedReceivingModAcc[acc], app1.keeper.bank.BlockedAddr(app1.keeper.acct.GetModuleAddress(acc)),
+		require.Equal(t, !allowedReceivingModAcc[acc], app1.Keepers.Cosmos.Bank.BlockedAddr(app1.Keepers.Cosmos.Acct.GetModuleAddress(acc)),
 			"ensure that blocked addresses are properly set in bank keeper")
 	}
 

--- a/app/export.go
+++ b/app/export.go
@@ -38,13 +38,13 @@ func (app *AkashApp) ExportAppStateAndValidators(
 		app.prepForZeroHeightGenesis(ctx, jailAllowedAddrs)
 	}
 
-	genState := app.mm.ExportGenesis(ctx, app.appCodec)
+	genState := app.MM.ExportGenesis(ctx, app.appCodec)
 	appState, err := json.MarshalIndent(genState, "", "  ")
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.keeper.staking)
+	validators, err := staking.WriteValidators(ctx, app.Keepers.Cosmos.Staking)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
@@ -79,18 +79,18 @@ func (app *AkashApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs 
 	}
 
 	/* Just to be safe, assert the invariants on current state. */
-	app.keeper.crisis.AssertInvariants(ctx)
+	app.Keepers.Cosmos.Crisis.AssertInvariants(ctx)
 
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission
-	app.keeper.staking.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
-		_, _ = app.keeper.distr.WithdrawValidatorCommission(ctx, val.GetOperator())
+	app.Keepers.Cosmos.Staking.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+		_, _ = app.Keepers.Cosmos.Distr.WithdrawValidatorCommission(ctx, val.GetOperator())
 		return false
 	})
 
 	// withdraw all delegator rewards
-	dels := app.keeper.staking.GetAllDelegations(ctx)
+	dels := app.Keepers.Cosmos.Staking.GetAllDelegations(ctx)
 	for _, delegation := range dels {
 		valAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
 		if err != nil {
@@ -101,28 +101,28 @@ func (app *AkashApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs 
 		if err != nil {
 			panic(err)
 		}
-		_, _ = app.keeper.distr.WithdrawDelegationRewards(ctx, delAddr, valAddr)
+		_, _ = app.Keepers.Cosmos.Distr.WithdrawDelegationRewards(ctx, delAddr, valAddr)
 	}
 
 	// clear validator slash events
-	app.keeper.distr.DeleteAllValidatorSlashEvents(ctx)
+	app.Keepers.Cosmos.Distr.DeleteAllValidatorSlashEvents(ctx)
 
 	// clear validator historical rewards
-	app.keeper.distr.DeleteAllValidatorHistoricalRewards(ctx)
+	app.Keepers.Cosmos.Distr.DeleteAllValidatorHistoricalRewards(ctx)
 
 	// set context height to zero
 	height := ctx.BlockHeight()
 	ctx = ctx.WithBlockHeight(0)
 
 	// reinitialize all validators
-	app.keeper.staking.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	app.Keepers.Cosmos.Staking.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
-		scraps := app.keeper.distr.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
-		feePool := app.keeper.distr.GetFeePool(ctx)
+		scraps := app.Keepers.Cosmos.Distr.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
+		feePool := app.Keepers.Cosmos.Distr.GetFeePool(ctx)
 		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
-		app.keeper.distr.SetFeePool(ctx, feePool)
+		app.Keepers.Cosmos.Distr.SetFeePool(ctx, feePool)
 
-		app.keeper.distr.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
+		app.Keepers.Cosmos.Distr.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
 		return false
 	})
 
@@ -137,8 +137,8 @@ func (app *AkashApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs 
 		if err != nil {
 			panic(err)
 		}
-		app.keeper.distr.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr)
-		app.keeper.distr.Hooks().AfterDelegationModified(ctx, delAddr, valAddr)
+		app.Keepers.Cosmos.Distr.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr)
+		app.Keepers.Cosmos.Distr.Hooks().AfterDelegationModified(ctx, delAddr, valAddr)
 	}
 
 	// reset context height
@@ -147,20 +147,20 @@ func (app *AkashApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs 
 	/* Handle staking state. */
 
 	// iterate through redelegations, reset creation height
-	app.keeper.staking.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
+	app.Keepers.Cosmos.Staking.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
 		for i := range red.Entries {
 			red.Entries[i].CreationHeight = 0
 		}
-		app.keeper.staking.SetRedelegation(ctx, red)
+		app.Keepers.Cosmos.Staking.SetRedelegation(ctx, red)
 		return false
 	})
 
 	// iterate through unbonding delegations, reset creation height
-	app.keeper.staking.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
+	app.Keepers.Cosmos.Staking.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
 		for i := range ubd.Entries {
 			ubd.Entries[i].CreationHeight = 0
 		}
-		app.keeper.staking.SetUnbondingDelegation(ctx, ubd)
+		app.Keepers.Cosmos.Staking.SetUnbondingDelegation(ctx, ubd)
 		return false
 	})
 
@@ -172,7 +172,7 @@ func (app *AkashApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs 
 
 	for ; iter.Valid(); iter.Next() {
 		addr := sdk.ValAddress(stakingtypes.AddressFromValidatorsKey(iter.Key()))
-		validator, found := app.keeper.staking.GetValidator(ctx, addr)
+		validator, found := app.Keepers.Cosmos.Staking.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")
 		}
@@ -182,22 +182,22 @@ func (app *AkashApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs 
 			validator.Jailed = true
 		}
 
-		app.keeper.staking.SetValidator(ctx, validator)
+		app.Keepers.Cosmos.Staking.SetValidator(ctx, validator)
 		counter++
 	}
 
-	iter.Close()
+	_ = iter.Close()
 
-	_, _ = app.keeper.staking.ApplyAndReturnValidatorSetUpdates(ctx)
+	_, _ = app.Keepers.Cosmos.Staking.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	/* Handle slashing state. */
 
 	// reset start height on signing infos
-	app.keeper.slashing.IterateValidatorSigningInfos(
+	app.Keepers.Cosmos.Slashing.IterateValidatorSigningInfos(
 		ctx,
 		func(addr sdk.ConsAddress, info slashingtypes.ValidatorSigningInfo) (stop bool) {
 			info.StartHeight = 0
-			app.keeper.slashing.SetValidatorSigningInfo(ctx, addr, info)
+			app.Keepers.Cosmos.Slashing.SetValidatorSigningInfo(ctx, addr, info)
 			return false
 		},
 	)

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -14,7 +14,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	simapp "github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/simapp/helpers"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -152,7 +152,7 @@ func TestAppImportExport(t *testing.T) {
 	ctxA := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
 	ctxB := newApp.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
 
-	newApp.mm.InitGenesis(ctxB, app.AppCodec(), genesisState)
+	newApp.MM.InitGenesis(ctxB, app.AppCodec(), genesisState)
 	newApp.StoreConsensusParams(ctxB, exported.ConsensusParams)
 
 	fmt.Printf("comparing stores...\n")

--- a/app/types/app.go
+++ b/app/types/app.go
@@ -1,0 +1,130 @@
+package types
+
+import (
+	"fmt"
+	"reflect"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v3/modules/apps/transfer/keeper"
+	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
+
+	"github.com/akash-network/node/x/audit"
+	"github.com/akash-network/node/x/cert"
+	dkeeper "github.com/akash-network/node/x/deployment/keeper"
+	escrowkeeper "github.com/akash-network/node/x/escrow/keeper"
+	agovkeeper "github.com/akash-network/node/x/gov/keeper"
+	"github.com/akash-network/node/x/inflation"
+	mkeeper "github.com/akash-network/node/x/market/keeper"
+	pkeeper "github.com/akash-network/node/x/provider/keeper"
+	astakingkeeper "github.com/akash-network/node/x/staking/keeper"
+)
+
+var (
+	upgrades = map[string]UpgradeInitFn{}
+)
+
+type IUpgrade interface {
+	StoreLoader() *storetypes.StoreUpgrades
+	UpgradeHandler() upgradetypes.UpgradeHandler
+}
+
+type UpgradeInitFn func(*App) (IUpgrade, error)
+
+type AppModules struct {
+	Cosmos struct{}
+	Akash  struct{}
+}
+
+type AppKeepers struct {
+	Cosmos struct {
+		Acct                 authkeeper.AccountKeeper
+		Authz                authzkeeper.Keeper
+		Bank                 bankkeeper.Keeper
+		Cap                  *capabilitykeeper.Keeper
+		Staking              stakingkeeper.Keeper
+		Slashing             slashingkeeper.Keeper
+		Mint                 mintkeeper.Keeper
+		Distr                distrkeeper.Keeper
+		Gov                  govkeeper.Keeper
+		Crisis               crisiskeeper.Keeper
+		Upgrade              upgradekeeper.Keeper
+		Params               paramskeeper.Keeper
+		IBC                  *ibckeeper.Keeper
+		Evidence             evidencekeeper.Keeper
+		Transfer             ibctransferkeeper.Keeper
+		ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
+		ScopedTransferKeeper capabilitykeeper.ScopedKeeper
+	}
+
+	Akash struct {
+		Escrow     escrowkeeper.Keeper
+		Deployment dkeeper.IKeeper
+		Market     mkeeper.IKeeper
+		Provider   pkeeper.IKeeper
+		Audit      audit.Keeper
+		Cert       cert.Keeper
+		Inflation  inflation.Keeper
+		Staking    astakingkeeper.IKeeper
+		Gov        agovkeeper.IKeeper
+	}
+}
+
+type App struct {
+	Keepers      AppKeepers
+	Modules      AppModules
+	Configurator module.Configurator
+	MM           *module.Manager
+}
+
+func RegisterUpgrade(name string, fn UpgradeInitFn) {
+	if _, exists := upgrades[name]; exists {
+		panic(fmt.Sprintf("upgrade \"%s\" already registered", name))
+	}
+
+	upgrades[name] = fn
+}
+
+func GetUpgradesList() map[string]UpgradeInitFn {
+	return upgrades
+}
+
+// FindStructField if an interface is either a struct or a pointer to a struct
+// and has the defined member field, if error is nil, the given
+// FieldName exists and is accessible with reflect.
+func FindStructField[C any](obj interface{}, fieldName string) (C, error) {
+	rValue := reflect.ValueOf(obj)
+
+	if rValue.Type().Kind() != reflect.Ptr {
+		return *new(C), fmt.Errorf("obj is not a pointer") // nolint: goerr113
+	}
+
+	field := rValue.Elem().FieldByName(fieldName)
+	if !field.IsValid() {
+		return *new(C), fmt.Errorf("interface `%s` does not have the field `%s`", rValue.Type(), fieldName) // nolint: goerr113
+	}
+
+	res, valid := field.Interface().(C)
+	if !valid {
+		return *new(C), fmt.Errorf( // nolint: goerr113
+			"object's `%s` expected type `%s` does not match actual `%s`",
+			fieldName,
+			reflect.TypeOf(*new(C)), field.Type().String())
+	}
+
+	return res, nil
+}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"fmt"
+
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	apptypes "github.com/akash-network/node/app/types"
+
+	// nolint: revive
+	_ "github.com/akash-network/node/app/upgrades/akash_v0.15.0_cosmos_v0.44.x"
+	// nolint: revive
+	_ "github.com/akash-network/node/app/upgrades/v0.20.0"
+)
+
+func (app *AkashApp) registerUpgradeHandlers() error {
+	upgradeInfo, err := app.Keepers.Cosmos.Upgrade.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		return err
+	}
+
+	for name, fn := range apptypes.GetUpgradesList() {
+		app.Logger().Info(fmt.Sprintf("initializing upgrade `%s`", name))
+		upgrade, err := fn(&app.App)
+		if err != nil {
+			return fmt.Errorf("unable to unitialize upgrade `%s`: %w", name, err)
+		}
+
+		app.Keepers.Cosmos.Upgrade.SetUpgradeHandler(name, upgrade.UpgradeHandler())
+		if storeUpgrades := upgrade.StoreLoader(); storeUpgrades != nil && upgradeInfo.Name == name {
+			app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, storeUpgrades))
+		}
+	}
+
+	return nil
+}

--- a/app/upgrades/akash_v0.15.0_cosmos_v0.44.x/upgrade.go
+++ b/app/upgrades/akash_v0.15.0_cosmos_v0.44.x/upgrade.go
@@ -1,0 +1,94 @@
+// Package akash_v0_15_0_cosmos_v0_44_x
+package akash_v0_15_0_cosmos_v0_44_x // nolint revive
+
+import (
+	inflationtypes "github.com/akash-network/akash-api/go/node/inflation/v1beta3"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibcconnectiontypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
+	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
+
+	apptypes "github.com/akash-network/node/app/types"
+)
+
+const (
+	upgradeName = "akash_v0.15.0_cosmos_v0.44.x"
+)
+
+func init() {
+	apptypes.RegisterUpgrade(upgradeName, initUpgrade)
+}
+
+type upgrade struct {
+	*apptypes.App
+	ibc *ibckeeper.Keeper
+}
+
+var _ apptypes.IUpgrade = (*upgrade)(nil)
+
+func initUpgrade(app *apptypes.App) (apptypes.IUpgrade, error) {
+	up := &upgrade{
+		App: app,
+	}
+
+	val, err := apptypes.FindStructField[*ibckeeper.Keeper](&app.Keepers.Cosmos, "IBC")
+	if err != nil {
+		return nil, err
+	}
+
+	up.ibc = val
+
+	return up, nil
+}
+
+func (up *upgrade) StoreLoader() *storetypes.StoreUpgrades {
+	upgrades := &storetypes.StoreUpgrades{
+		Added: []string{
+			authz.ModuleName,
+			inflationtypes.ModuleName,
+		},
+	}
+
+	return upgrades
+}
+
+func (up *upgrade) UpgradeHandler() upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, versionMap module.VersionMap) (module.VersionMap, error) {
+		// set max expected block time parameter. Replace the default with your expected value
+		up.ibc.ConnectionKeeper.SetParams(ctx, ibcconnectiontypes.DefaultParams())
+
+		// 1st-time running in-store migrations, using 1 as fromVersion to
+		// avoid running InitGenesis.
+		fromVM := map[string]uint64{
+			"auth":         1,
+			"bank":         1,
+			"capability":   1,
+			"crisis":       1,
+			"distribution": 1,
+			"evidence":     1,
+			"gov":          1,
+			"mint":         1,
+			"params":       1,
+			"slashing":     1,
+			"staking":      1,
+			"upgrade":      1,
+			"vesting":      1,
+			"ibc":          1,
+			"genutil":      1,
+			"transfer":     1,
+
+			// akash modules
+			"audit":      1,
+			"cert":       1,
+			"deployment": 1,
+			"escrow":     1,
+			"market":     1,
+			"provider":   1,
+		}
+
+		return up.MM.RunMigrations(ctx, up.Configurator, fromVM)
+	}
+}

--- a/app/upgrades/readme.md
+++ b/app/upgrades/readme.md
@@ -1,0 +1,26 @@
+# Upgrade handlers
+
+## Upgrades history
+
+### v0.20.0
+ - disable and remove Cosmos Inter Chain Accounts (ICA) due to issues discovered post v0.18.0
+ 
+### v0.18.0
+Key features that this upgrade enables are:
+ - support for IP Leases on the Akash marketplace
+ - initial phases of splitting provider services into microservices
+ - code changes to support Cosmos Inter Chain Accounts (ICA) and IBC3.
+
+
+### akash_v0.15.0_cosmos_v0.44.x
+
+## How to add a new upgrade handler to the app
+
+1. use [akash_v0.15.0_cosmos_v0.44.x](./akash_v0.15.0_cosmos_v0.44.x) as an example
+2. import new upgrade module into [app/upgrades](../upgrades.go)
+   ```go
+   import (
+       _ "github.com/akash-network/node/app/upgrades/akash_v0.15.0_cosmos_v0.44.x"
+   )
+3. Once imported, the upgrade will register itself, and `App` will initialize it during startup
+4. To deregister obsolete upgrade simply remove respective import from [app/upgrades](../upgrades.go)

--- a/app/upgrades/v0.18.0/upgrade.go
+++ b/app/upgrades/v0.18.0/upgrade.go
@@ -1,0 +1,82 @@
+// Package v0_18_0
+package v0_18_0 // nolint revive
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ica "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts"
+	icacontrollertypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+
+	apptypes "github.com/akash-network/node/app/types"
+)
+
+const (
+	upgradeName = "v0.18.0"
+)
+
+func init() {
+	apptypes.RegisterUpgrade(upgradeName, initUpgrade)
+}
+
+type upgrade struct {
+	*apptypes.App
+	icaModule ica.AppModule
+}
+
+var _ apptypes.IUpgrade = (*upgrade)(nil)
+
+func initUpgrade(app *apptypes.App) (apptypes.IUpgrade, error) {
+	up := &upgrade{
+		App: app,
+	}
+
+	val, err := apptypes.FindStructField[ica.AppModule](&app.Modules.Cosmos, "ICAModule")
+	if err != nil {
+		return nil, err
+	}
+
+	up.icaModule = val
+
+	return up, nil
+}
+
+func (up *upgrade) StoreLoader() *storetypes.StoreUpgrades {
+	upgrades := &storetypes.StoreUpgrades{
+		Added: []string{
+			icacontrollertypes.StoreKey,
+			icahosttypes.StoreKey,
+		},
+	}
+
+	return upgrades
+}
+
+func (up *upgrade) UpgradeHandler() upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		fromVM[icatypes.ModuleName] = up.icaModule.ConsensusVersion()
+
+		// create ICS27 Controller submodule params
+		// enable the controller chain
+		controllerParams := icacontrollertypes.Params{ControllerEnabled: true}
+
+		// create ICS27 Host submodule params
+		hostParams := icahosttypes.Params{
+			// enable the host chain
+			HostEnabled: true,
+			// allowing the all messages
+			AllowMessages: []string{"*"},
+		}
+
+		ctx.Logger().Info("start to init interchainaccount module...")
+		// initialize ICS27 module
+		up.icaModule.InitModule(ctx, controllerParams, hostParams)
+
+		ctx.Logger().Info("start to run module migrations...")
+
+		return up.MM.RunMigrations(ctx, up.Configurator, fromVM)
+	}
+}

--- a/app/upgrades/v0.20.0/upgrade.go
+++ b/app/upgrades/v0.20.0/upgrade.go
@@ -1,0 +1,59 @@
+// Package v0_20_0
+package v0_20_0 // nolint revive
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	icacontrollertypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+
+	apptypes "github.com/akash-network/node/app/types"
+)
+
+const (
+	upgradeName = "v0.20.0"
+)
+
+func init() {
+	apptypes.RegisterUpgrade(upgradeName, initUpgrade)
+}
+
+type upgrade struct {
+	*apptypes.App
+}
+
+var _ apptypes.IUpgrade = (*upgrade)(nil)
+
+func initUpgrade(app *apptypes.App) (apptypes.IUpgrade, error) {
+	up := &upgrade{
+		App: app,
+	}
+
+	return up, nil
+}
+
+func (up *upgrade) StoreLoader() *storetypes.StoreUpgrades {
+	upgrades := &storetypes.StoreUpgrades{
+		Deleted: []string{
+			icacontrollertypes.StoreKey,
+			icahosttypes.StoreKey,
+		},
+	}
+
+	return upgrades
+}
+
+func (up *upgrade) UpgradeHandler() upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("start to roll-back interchainaccount module...")
+
+		delete(fromVM, icatypes.ModuleName)
+
+		ctx.Logger().Info("start to run module migrations...")
+
+		return up.MM.RunMigrations(ctx, up.Configurator, fromVM)
+	}
+}


### PR DESCRIPTION
- move keepers and app modules into dedicated struct with public members allows upgrade handlers to access necessary objects during initialization
- move each upgrade into dedicated package

refs akash-network/support#73