### PR TITLE
fix(lint): replace deadcode linter with unused

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -1,4 +1,4 @@
-SUBLINTERS = deadcode \
+SUBLINTERS = unused \
 			misspell \
 			goerr113 \
 			gofmt \


### PR DESCRIPTION
deadcode has been deprecated from golangci-lint 1.49
