### PR TITLE
fix: bump akash-api to v0.0.12

### DIFF
--- a/cmd/akash/cmd/root.go
+++ b/cmd/akash/cmd/root.go
@@ -35,8 +35,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
-	"github.com/akash-network/akash-api/go/sdkutil"
-
 	"github.com/akash-network/node/app"
 	ecmd "github.com/akash-network/node/events/cmd"
 	utilcli "github.com/akash-network/node/util/cli"
@@ -102,7 +100,6 @@ func Execute(rootCmd *cobra.Command, envPrefix string) error {
 }
 
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
-	sdkutil.InitSDKConfig()
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
 		ecmd.EventCmd(),

--- a/cmd/akash/main.go
+++ b/cmd/akash/main.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/server"
 
+	_ "github.com/akash-network/akash-api/go/sdkutil"
+
 	"github.com/akash-network/node/cmd/akash/cmd"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akash-network/node
 go 1.20
 
 require (
-	github.com/akash-network/akash-api v0.0.10
+	github.com/akash-network/akash-api v0.0.12
 	github.com/blang/semver/v4 v4.0.0
 	github.com/boz/go-lifecycle v0.1.0
 	github.com/cosmos/cosmos-sdk v0.45.15
@@ -33,6 +33,7 @@ require (
 replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+
 	// use akash version of cosmos ledger api
 	github.com/cosmos/ledger-cosmos-go => github.com/akash-network/ledger-go/cosmos v0.14.3
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/akash-network/akash-api v0.0.10 h1:tminfU9G5vE1ZutlFEUdcifUJvlg5lkT+F0OWytNMSM=
-github.com/akash-network/akash-api v0.0.10/go.mod h1:e1QqkOFwxHKf88I3U5bPOmREdfHHHX2bY27ZZOFnTX4=
+github.com/akash-network/akash-api v0.0.12 h1:j3PPC6ouI1PcuKbxyuO8ffyVcaZsT3ZDPprQo3KxPYk=
+github.com/akash-network/akash-api v0.0.12/go.mod h1:e1QqkOFwxHKf88I3U5bPOmREdfHHHX2bY27ZZOFnTX4=
 github.com/akash-network/cometbft v0.34.27-akash h1:V1dApDOr8Ee7BJzYyQ7Z9VBtrAul4+baMeA6C49dje0=
 github.com/akash-network/cometbft v0.34.27-akash/go.mod h1:BcCbhKv7ieM0KEddnYXvQZR+pZykTKReJJYf7YC7qhw=
 github.com/akash-network/ledger-go v0.14.3 h1:LCEFkTfgGA2xFMN2CtiKvXKE7dh0QSM77PJHCpSkaAo=

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -9,19 +9,15 @@ import (
 
 	dtypes "github.com/akash-network/akash-api/go/node/deployment/v1beta3"
 	types "github.com/akash-network/akash-api/go/node/types/v1beta3"
-)
 
-func init() {
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(BechPrefix, BechPrefix)
-	config.Seal()
-}
+	// ensure sdkutil.init() to seal SDK config for the tests
+	_ "github.com/akash-network/akash-api/go/sdkutil"
+)
 
 // CoinDenom provides ability to create coins in test functions and
 // pass them into testutil functionality.
 const (
-	CoinDenom  = "uakt"
-	BechPrefix = "akash"
+	CoinDenom = "uakt"
 )
 
 // Name generates a random name with the given prefix


### PR DESCRIPTION
remove init of SDK Config and rely on one akash-api

Signed-off-by: Artur Troian <troian.ap@gmail.com>

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/master/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
