### PR TITLE
refactor: default logger. log to stdout

### DIFF
--- a/cmd/akash/cmd/root.go
+++ b/cmd/akash/cmd/root.go
@@ -94,6 +94,7 @@ func Execute(rootCmd *cobra.Command, envPrefix string) error {
 
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic)")
 	rootCmd.PersistentFlags().String(flags.FlagLogFormat, tmcfg.LogFormatPlain, "The logging format (json|plain)")
+	rootCmd.PersistentFlags().Bool(utilcli.FlagLogColor, false, "Pretty logging output. Applied only when log_format=plain")
 
 	executor := tmcli.PrepareBaseCmd(rootCmd, envPrefix, app.DefaultHome)
 	return executor.ExecuteContext(ctx)

--- a/util/cli/configs.go
+++ b/util/cli/configs.go
@@ -9,14 +9,20 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
 	tmcfg "github.com/tendermint/tendermint/config"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/server/config"
+)
+
+const (
+	FlagLogColor = "log_color"
 )
 
 var (
@@ -67,9 +73,13 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, envPrefixes []string, all
 
 	var logWriter io.Writer
 	if strings.ToLower(serverCtx.Viper.GetString(flags.FlagLogFormat)) == tmcfg.LogFormatPlain {
-		logWriter = zerolog.ConsoleWriter{Out: os.Stderr}
+		if serverCtx.Viper.GetBool(FlagLogColor) {
+			logWriter = zerolog.ConsoleWriter{Out: os.Stdout}
+		} else {
+			logWriter = zerolog.New(os.Stdout)
+		}
 	} else {
-		logWriter = os.Stderr
+		logWriter = os.Stdout
 	}
 
 	logLvlStr := serverCtx.Viper.GetString(flags.FlagLogLevel)


### PR DESCRIPTION
disable colored output by default

Signed-off-by: Artur Troian <troian.ap@gmail.com>

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/master/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
