### PR TITLE
fix: remove redundant v prefix from detected version

### DIFF
--- a/make/init.mk
+++ b/make/init.mk
@@ -59,7 +59,7 @@ ifeq ($(DETECTED_OS), Darwin)
 
 	# on MacOS Sonoma Beta there is a bit of discrepancy between Go and new prime linker
 	clang_version := $(shell echo | clang -dM -E - | grep __clang_major__ | cut -d ' ' -f 3 | tr -d '\n')
-	go_has_ld_fix := $(shell $(SEMVER) compare "v$(GOTOOLCHAIN_SEMVER)" "v1.22.0" | tr -d '\n')
+	go_has_ld_fix := $(shell $(SEMVER) compare "$(GOTOOLCHAIN_SEMVER)" "v1.22.0" | tr -d '\n')
 
 	ifeq (15,$(clang_version))
 		ifeq (-1,$(go_has_ld_fix))


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
