### PR TITLE
docs(readme): remove stable and unstable version ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ found in the [design documentation](https://docs.akash.network); and the target 
 
 The `main` branch contains new features and is under active development; the `mainnet/main` branch contains the current, stable release.
 
-* **stable** releases will have even minor numbers ( `v0.8.0` ) and be cut from the `mainnet/main` branch.
-* **unstable** releases will have odd minor numbers ( `v0.9.0` ) and be cut from the `main` branch.
+* **stable** releases will have even minor numbers (e.g. `v0.8.0`) and be cut from the `mainnet/main` branch.
+* **unstable** releases will have odd minor numbers (e.g. `v0.9.0`) and be cut from the `main` branch.
 
 ## Akash Suite
 


### PR DESCRIPTION
I got the impression that the latest stable version was `v0.8.0` and latest unstable version was `v0.9.0` while looking at the README's "Branching and Versioning" section.

But in reality the latest are `v0.30.0` and `v0.29.0` respectively at the time of writing this commit message.
Hence adding an `e.g.` to the README page.

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
