### PR TITLE
fix(upgrades): correct typo in source file

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -20,7 +20,7 @@ func (app *AkashApp) registerUpgradeHandlers() error {
 		app.Logger().Info(fmt.Sprintf("initializing upgrade `%s`", name))
 		upgrade, err := fn(app.Logger(), &app.App)
 		if err != nil {
-			return fmt.Errorf("unable to unitialize upgrade `%s`: %w", name, err)
+			return fmt.Errorf("unable to uninitialize upgrade `%s`: %w", name, err)
 		}
 
 		app.Keepers.Cosmos.Upgrade.SetUpgradeHandler(name, upgrade.UpgradeHandler())


### PR DESCRIPTION
fix(upgrades): correct typo in source file

Corrected a typo in `app/upgrades.go:23` where "unitialize" was updated to "uninitialize".

Purpose:
- Enhanced code accuracy and professionalism by fixing the typo.

