### PR TITLE
chore: wrong link in adr-001-network-upgrades.md

### DIFF
--- a/_docs/adr/adr-001-network-upgrades.md
+++ b/_docs/adr/adr-001-network-upgrades.md
@@ -180,7 +180,7 @@ func migrateDeploymentGroup(fromBz []byte, cdc codec.BinaryCodec) codec.ProtoMar
    )
    ```
 2. Once imported, the upgrade will register itself, and `App` will initialize it during startup
-3. To deregister obsolete upgrade simply remove respective import from [upgrades/upgrades.go](../upgrades/upgrades.go)
+3. To deregister obsolete upgrade simply remove respective import from [upgrades/upgrades.go](../../upgrades/upgrades.go)
 
 ##### Testing software upgrade
 1. cd `tests/upgrade`


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Path to `../upgrades/upgrades.go` should be `../../upgrades/upgrades.go` in [adr-001-network-upgrades.md](https://github.com/akash-network/node/blob/main/_docs/adr/adr-001-network-upgrades.md)