### PR TITLE
Typo fix in the file upgrades.go

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -20,7 +20,7 @@ func (app *AkashApp) registerUpgradeHandlers() error {
 		app.Logger().Info(fmt.Sprintf("initializing upgrade `%s`", name))
 		upgrade, err := fn(app.Logger(), &app.App)
 		if err != nil {
-			return fmt.Errorf("unable to unitialize upgrade `%s`: %w", name, err)
+			return fmt.Errorf("unable to uninitialize upgrade `%s`: %w", name, err)
 		}
 
 		app.Keepers.Cosmos.Upgrade.SetUpgradeHandler(name, upgrade.UpgradeHandler())


### PR DESCRIPTION
# Typo Fix in `upgrades.go`

## Description

This pull request fixes a typo in the `upgrades.go` file within the `akash-network` repository. The word **"unitialize"** has been corrected to **"uninitialize"**.

### Changes Made:
1. **Fixed Typo**:
   - **"unitialize"** → **"uninitialize"**


