### PR TITLE
Corrected typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,4 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* Fix bug in ditribution and querying rewards
+* Fix bug in distribution and querying rewards

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -20,7 +20,7 @@ func (app *AkashApp) registerUpgradeHandlers() error {
 		app.Logger().Info(fmt.Sprintf("initializing upgrade `%s`", name))
 		upgrade, err := fn(app.Logger(), &app.App)
 		if err != nil {
-			return fmt.Errorf("unable to unitialize upgrade `%s`: %w", name, err)
+			return fmt.Errorf("unable to uninitialize upgrade `%s`: %w", name, err)
 		}
 
 		app.Keepers.Cosmos.Upgrade.SetUpgradeHandler(name, upgrade.UpgradeHandler())

--- a/pubsub/bus.go
+++ b/pubsub/bus.go
@@ -109,7 +109,7 @@ func (b *bus) run() {
 	defer b.lc.ShutdownCompleted()
 
 	var outch chan<- Event
-	var curev Event
+	var curve Event
 
 loop:
 	for {
@@ -119,7 +119,7 @@ loop:
 			// are events to emit, set up the output channel and output
 			// event accordingly.
 			outch = b.eventch
-			curev = b.evbuf[0]
+			curve = b.evbuf[0]
 		} else {
 			// otherwise block the output (sending to a nil channel always blocks)
 			outch = nil
@@ -130,7 +130,7 @@ loop:
 			b.lc.ShutdownInitiated(err)
 			break loop
 
-		case outch <- curev:
+		case outch <- curve:
 			// Event was emitted. Shrink current event buffer.
 			b.evbuf = b.evbuf[1:]
 
@@ -178,7 +178,7 @@ loop:
 }
 
 func newSubscriber(parent *bus) *bus {
-	// Re-use bus struct, but populate output channel (eventch)
+	// Reuse bus struct, but populate output channel (eventch)
 	// to enable subscriber mode.
 
 	evbuf := make([]Event, len(parent.evbuf))

--- a/sdl/v2_1_test.go
+++ b/sdl/v2_1_test.go
@@ -171,7 +171,7 @@ func Test_V2_1_Cross_Validates(t *testing.T) {
 
 	// This is a single document producing both the manifest & deployment groups
 	// These should always agree with each other. If this test fails at least one of the
-	// following is ture
+	// following is true, pure
 	// 1. Cross validation logic is wrong
 	// 2. The DeploymentGroups() & Manifest() code do not agree with one another
 	err = m.CheckAgainstGSpecs(dgroups)

--- a/sdl/v2_test.go
+++ b/sdl/v2_test.go
@@ -213,7 +213,7 @@ func Test_V2_Cross_Validates(t *testing.T) {
 
 	// This is a single document producing both the manifest & deployment groups
 	// These should always agree with each other. If this test fails at least one of the
-	// following is ture
+	// following is true, pure
 	// 1. Cross validation logic is wrong
 	// 2. The DeploymentGroups() & Manifest() code do not agree with one another
 	err = m.CheckAgainstGSpecs(dgroups)

--- a/upgrades/CHANGELOG.md
+++ b/upgrades/CHANGELOG.md
@@ -49,7 +49,7 @@ Add new upgrades after this line based on the template above
 
 ##### v0.34.0
 
-1. Extend authz implementation for DeploymentDeposit to allow grantee re-use of unspent funds.
+1. Extend authz implementation for DeploymentDeposit to allow grantee reuse of unspent funds.
     - Example of previous behavior:
       Deployment authz granted from account B (grantor) to account A (grantee) in amount of 5AKT.
       Deployment is created with authorized spend and deposit amount of 3AKT.


### PR DESCRIPTION
Changes made in:

- /CODE_OF_CONDUCT.md ("socio-economic" → "socioeconomic")

- /CHANGELOG.md ("ditribution" → "distribution")

- /upgrades/CHANGELOG.md ("re-use" → "reuse")

- /app/upgrades.go ("unitialize" → "uninitialize")

- /sdl/v2_test.go ("ture" → "true, pure")

- /sdl/v2_1_test.go ("ture" → "true, pure")

- /pubsub/bus.go ("curev" → "curve")

- /pubsub/bus.go ("curev" → "curve")

- /pubsub/bus.go ("curev" → "curve")

- /pubsub/bus.go ("Re-use" → "Reuse")
