### PR TITLE
refactor(event): parse events after querying block results

### DIFF
--- a/events/query.go
+++ b/events/query.go
@@ -8,12 +8,17 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-func txQuery() pubsub.Query {
-	return tmquery.MustParse(
-		fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventTx))
-}
+// func txQuery() pubsub.Query {
+// 	return tmquery.MustParse(
+// 		fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventTx))
+// }
+//
+// func blkQuery() pubsub.Query {
+// 	return tmquery.MustParse(
+// 		fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventNewBlock))
+// }
 
-func blkQuery() pubsub.Query {
+func blkHeaderQuery() pubsub.Query {
 	return tmquery.MustParse(
 		fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventNewBlockHeader))
 }


### PR DESCRIPTION
fixes issue with server side of websocket closing subscription due to client not reading events fast. this happens when block has substantial amount of txs thus events count can be > 1000. this implementation now just waits for event with block header then queries block info and parses events.
