### PR TITLE
Fix broken link to AEP-61

### DIFF
--- a/upgrades/CHANGELOG.md
+++ b/upgrades/CHANGELOG.md
@@ -46,7 +46,7 @@ Add new upgrades after this line based on the template above
 
 ##### v0.38.0
 
-Upgrade x/stores keys to improve read performance of certain modules as described in [AEP-61](https://github.com/akash-network/AEP/blob/main/AEPS/AEP-61.md)
+Upgrade x/stores keys to improve read performance of certain modules as described in [AEP-61](https://github.com/akash-network/AEP/blob/main/spec/aep-61/README.md)
 
 - Migrations
     - cert `2 -> 3`


### PR DESCRIPTION

Old:
[AEP-61]  (https://github.com/akash-network/AEP/blob/main/AEPS/AEP-61.md)

New:
[AEP-61]. (https://github.com/akash-network/AEP/blob/main/spec/aep-61/README.md)


The previous link was either outdated or led to a non-existent resource. This fix ensures that readers and contributors are directed to the correct and updated AEP-61 documentation, improving accuracy and maintainability.

