### PR TITLE
fix: fix slice init length

### DIFF
--- a/x/audit/keeper/keeper_test.go
+++ b/x/audit/keeper/keeper_test.go
@@ -112,7 +112,7 @@ func TestProviderDeleteNonExistingAttributes(t *testing.T) {
 	require.NoError(t, err)
 
 	attr := testutil.Attributes(t)
-	keys := make([]string, len(attr))
+	keys := make([]string, 0, len(attr))
 
 	for _, entry := range attr {
 		keys = append(keys, entry.Key)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The intention here should be to initialize a slice with a capacity of len(attr) rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW

Benefit:

- Correctness: Only contains elements we add.
- Efficiency: Avoids unnecessary memory reallocations.



<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the construction of test data in provider attribute deletion tests to ensure accuracy and prevent unintended extra elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->