### PR TITLE
Fix Typos in Error Messages and Improve Consistency

### DIFF
--- a/x/escrow/genesis.go
+++ b/x/escrow/genesis.go
@@ -54,7 +54,7 @@ func ValidateGenesis(data *types.GenesisState) error {
 		for _, p2 := range pmap[payment.AccountID] {
 			if p2.PaymentID == payment.PaymentID {
 				return fmt.Errorf(
-					"%w, dupliate payment for %s %s (idx %v)", types.ErrPaymentExists, payment.AccountID, payment.PaymentID, idx)
+					"%w, duplicate payment for %s %s (idx %v)", types.ErrPaymentExists, payment.AccountID, payment.PaymentID, idx)
 			}
 		}
 

--- a/x/market/handler/server.go
+++ b/x/market/handler/server.go
@@ -32,10 +32,10 @@ func (ms msgServer) CreateBid(goCtx context.Context, msg *types.MsgCreateBid) (*
 
 	minDeposit := params.BidMinDeposit
 	if msg.Deposit.Denom != minDeposit.Denom {
-		return nil, fmt.Errorf("%w: mininum:%v received:%v", types.ErrInvalidDeposit, minDeposit, msg.Deposit)
+		return nil, fmt.Errorf("%w: minimum:%v received:%v", types.ErrInvalidDeposit, minDeposit, msg.Deposit)
 	}
 	if minDeposit.Amount.GT(msg.Deposit.Amount) {
-		return nil, fmt.Errorf("%w: mininum:%v received:%v", types.ErrInvalidDeposit, minDeposit, msg.Deposit)
+		return nil, fmt.Errorf("%w: minimum:%v received:%v", types.ErrInvalidDeposit, minDeposit, msg.Deposit)
 	}
 
 	if ms.keepers.Market.BidCountForOrder(ctx, msg.Order) > params.OrderMaxBids {


### PR DESCRIPTION


Description:  
- Corrected the typo "dupliate" to "duplicate" in escrow/genesis.go error message.
- Improved clarity and consistency of error outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typographical errors in error messages to improve clarity and professionalism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->