### PR TITLE
fix(x/market): initialize reverse indicies during genesis import

### DIFF
--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -7,6 +7,12 @@ import (
 	"os"
 	"testing"
 
+	atypes "github.com/akash-network/akash-api/go/node/audit/v1beta3"
+	ctypes "github.com/akash-network/akash-api/go/node/cert/v1beta3"
+	dtypes "github.com/akash-network/akash-api/go/node/deployment/v1beta3"
+	mtypes "github.com/akash-network/akash-api/go/node/market/v1beta4"
+	ptypes "github.com/akash-network/akash-api/go/node/provider/v1beta3"
+	taketypes "github.com/akash-network/akash-api/go/node/take/v1beta3"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	"github.com/stretchr/testify/require"
@@ -181,6 +187,36 @@ func TestAppImportExport(t *testing.T) {
 		{app.skeys[authz.ModuleName], newApp.skeys[authz.ModuleName], [][]byte{
 			authzkeeper.GranteeKey,
 		}},
+		{
+			app.GetKey(atypes.StoreKey),
+			newApp.GetKey(atypes.StoreKey),
+			[][]byte{},
+		},
+		{
+			app.GetKey(ctypes.StoreKey),
+			newApp.GetKey(ctypes.StoreKey),
+			[][]byte{},
+		},
+		{
+			app.GetKey(dtypes.StoreKey),
+			newApp.GetKey(dtypes.StoreKey),
+			[][]byte{},
+		},
+		{
+			app.GetKey(mtypes.StoreKey),
+			newApp.GetKey(mtypes.StoreKey),
+			[][]byte{},
+		},
+		{
+			app.GetKey(ptypes.StoreKey),
+			newApp.GetKey(ptypes.StoreKey),
+			[][]byte{},
+		},
+		{
+			app.GetKey(taketypes.StoreKey),
+			newApp.GetKey(taketypes.StoreKey),
+			[][]byte{},
+		},
 	}
 
 	for _, skp := range storeKeysPrefixes {

--- a/x/market/genesis.go
+++ b/x/market/genesis.go
@@ -48,22 +48,35 @@ func InitGenesis(ctx sdk.Context, kpr keeper.IKeeper, data *types.GenesisState) 
 
 	for _, record := range data.Bids {
 		key := keys.MustBidKey(keys.BidStateToPrefix(record.State), record.ID())
+		revKey := keys.MustBidReverseKey(keys.BidStateToPrefix(record.State), record.ID())
 
 		if store.Has(key) {
 			panic(fmt.Errorf("market genesis bids init. bid id %s: %w", record.ID(), types.ErrBidExists))
 		}
+		if store.Has(revKey) {
+			panic(fmt.Errorf("market genesis bids init. reverse key for bid id %s: %w", record.ID(), types.ErrBidExists))
+		}
 
-		store.Set(key, cdc.MustMarshal(&record))
+		data := cdc.MustMarshal(&record)
+		store.Set(key, data)
+		store.Set(revKey, data)
 	}
 
 	for _, record := range data.Leases {
 		key := keys.MustLeaseKey(keys.LeaseStateToPrefix(record.State), record.ID())
+		revKey := keys.MustLeaseReverseKey(keys.LeaseStateToPrefix(record.State), record.ID())
 
 		if store.Has(key) {
-			panic(fmt.Errorf("market genesis leases init. order id %s: lease exists", record.ID()))
+			panic(fmt.Errorf("market genesis leases init. lease id %s: lease exists", record.ID()))
 		}
 
-		store.Set(key, cdc.MustMarshal(&record))
+		if store.Has(revKey) {
+			panic(fmt.Errorf("market genesis leases init. reverse key for lease id %s: lease exists", record.ID()))
+		}
+
+		data := cdc.MustMarshal(&record)
+		store.Set(key, data)
+		store.Set(revKey, data)
 	}
 
 	kpr.SetParams(ctx, data.Params)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded import/export tests to verify state consistency for additional modules, improving coverage and reliability.

* **Bug Fixes**
  * Ensured bid and lease records are stored with both forward and reverse keys during initialization, preventing potential data inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->