### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/concommits.yaml
+++ b/.github/workflows/concommits.yaml
@@ -13,5 +13,5 @@ jobs:
     name: conventional commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: webiny/action-conventional-commits@v1.1.0

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/labeler@v5
         with:
           configuration-path: .github/labeler.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -49,7 +49,7 @@ jobs:
     needs:
       - publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -87,7 +87,7 @@ jobs:
     needs:
       - publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: release version

--- a/.github/workflows/standardize-yaml.yaml
+++ b/.github/workflows/standardize-yaml.yaml
@@ -10,7 +10,7 @@ jobs:
   check-yml-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: check-yml-count
         run: |
           if [[ $(git ls-files '*.yml' ':!:codecov.yml' | wc -l) -ne 0 ]]; then git ls-files '*.yml' ':!:codecov.yml' && exit 1;fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo chsh -s /usr/local/bin/bash
       - name: Hook direnv to bash
         run: echo 'eval "$(direnv hook bash)"' >> $HOME/.bashrc
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -42,7 +42,7 @@ jobs:
   build-bins:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -60,7 +60,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -76,7 +76,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -93,7 +93,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -115,7 +115,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -134,7 +134,7 @@ jobs:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Detect required Go version
         run: |
           toolchain=$(./script/tools.sh gotoolchain | sed 's/go*//')
@@ -156,7 +156,7 @@ jobs:
   release-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -186,7 +186,7 @@ jobs:
         run: |
           sudo rm -rf ./* || true
           sudo rm -rf ./.??* || true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -229,7 +229,7 @@ jobs:
         run: |
           sudo rm -rf ./* || true
           sudo rm -rf ./.??* || true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
       - name: Detect required Go version
         run: |
@@ -285,7 +285,7 @@ jobs:
       - network-upgrade
       - shellcheck
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: trigger release process

--- a/.github/workflows/wip.yaml
+++ b/.github/workflows/wip.yaml
@@ -13,7 +13,7 @@ jobs:
   wip:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: akash-network/wip-check@v1
         with:
           labels: '["do-not-merge", "wip", "rfc"]'


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0